### PR TITLE
Fix process.send crash when not running as child

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,5 +46,7 @@ app.listen(port, () => {
 	console.log(`- Local: http://127.0.0.1:${port}/discord/webhook`);
 	localLinks.forEach(link => console.log(`- Network: ${link}/discord/webhook`));
 
-	if (process.env.NODE_ENV === 'production') process.send('ready');
+        if (process.env.NODE_ENV === 'production' && typeof process.send === 'function') {
+                process.send('ready');
+        }
 });


### PR DESCRIPTION
## Summary
- check for `process.send` call in `index.js` (pm2 not used in docker)